### PR TITLE
Fixed depth in phrases

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,14 +13,14 @@ PI:3.141592653589798238
 PUN:",;:.!?"
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
+  "j"$sum(and)scan 1b,-1_{1=count distinct count each x}each raze scan x]}
 fac:{prd 1+til x}                       / factorial
 ly:{mod[;2] sum 0=x mod\:4 100 400}     / is x a leap year?
 oa:{x xexp/:0 1}                        / ones and all Xs (float)
 oe:{x xexp\:0 1}                        / 1 and each X (float)
 shape:{$[0=d:depth x; 
   0#0j; 
-  d#{first raze over x}each(d{each[x;]}\count)@\:x]}  / FIXME correct for shape 0#0
+  d#{first raze over x}each(d{each[x;]}\count)@\:x]}
 tc:('[til;count])
 tt:{2 vs til "j"$2 xexp x}              / truth table of order x
 zm:{(2#count x)#0}                      / zero matrix (square matrix)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ PI:3.141592653589798238
 PUN:",;:.!?"
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze over x]}
+  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
 fac:{prd 1+til x}                       / factorial
 ly:{mod[;2] sum 0=x mod\:4 100 400}     / is x a leap year?
 oa:{x xexp/:0 1}                        / ones and all Xs (float)

--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -81,7 +81,7 @@ The [_depth_](/q/basics/glossary/#depth) of a list is the number of nesting leve
 Its _shape_ is a vector of its count at each level at which it is rectangular, and corresponds to the left argument of [Take](/q/ref/take/).
 
 ```q
-q)depth:{$[type[x]<0; 0; "j"$sum(and)scan{1=count distinct count each x}each(raze\)x]}
+q)depth:{$[type[x]<0; 0; "j"$sum(and)scan 1b,-1_{1=count distinct count each x}each(raze\)x]}
 q)shape:{$[0=d:depth x; 0#0j; d#{first(raze/)x}each(d{each[x;]}\count)@\:x]}
 q)ix:('[{x vs til prd x};shape])
 q)ix til 6

--- a/docs/phrases.md
+++ b/docs/phrases.md
@@ -12,7 +12,7 @@ PI:3.141592653589798238
 PUN:",;:.!?"
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze over x]}
+  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
 fac:{prd 1+til x}                       / factorial
 ly:{mod[;2] sum 0=x mod\:4 100 400}     / is x a leap year?
 oa:{x xexp/:0 1}                        / ones and all Xs (float)

--- a/docs/phrases.md
+++ b/docs/phrases.md
@@ -12,14 +12,14 @@ PI:3.141592653589798238
 PUN:",;:.!?"
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
+  "j"$sum(and)scan 1b,-1_{1=count distinct count each x}each raze scan x]}
 fac:{prd 1+til x}                       / factorial
 ly:{mod[;2] sum 0=x mod\:4 100 400}     / is x a leap year?
 oa:{x xexp/:0 1}                        / ones and all Xs (float)
 oe:{x xexp\:0 1}                        / 1 and each X (float)
 shape:{$[0=d:depth x; 
   0#0j; 
-  d#{first raze over x}each(d{each[x;]}\count)@\:x]}  / FIXME correct for shape 0#0
+  d#{first raze over x}each(d{each[x;]}\count)@\:x]}
 tc:('[til;count])
 tt:{2 vs til "j"$2 xexp x}              / truth table of order x
 zm:{(2#count x)#0}                      / zero matrix (square matrix)

--- a/docs/phrases.q
+++ b/docs/phrases.q
@@ -6,7 +6,7 @@ PI:3.141592653589798238
 PUN:",;:.!?"
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze over x]}
+  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
 fac:{prd 1+til x}                   	/ factorial
 ly:{mod[;2] sum 0=x mod\:4 100 400}   	/ is x a leap year?
 oa:{x xexp/:0 1}                       	/ ones and all Xs (float)

--- a/docs/phrases.q
+++ b/docs/phrases.q
@@ -6,14 +6,14 @@ PI:3.141592653589798238
 PUN:",;:.!?"
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
+  "j"$sum(and)scan 1b,-1_{1=count distinct count each x}each raze scan x]}
 fac:{prd 1+til x}                   	/ factorial
 ly:{mod[;2] sum 0=x mod\:4 100 400}   	/ is x a leap year?
 oa:{x xexp/:0 1}                       	/ ones and all Xs (float)
 oe:{x xexp\:0 1}                       	/ 1 and each X (float)
 shape:{$[0=d:depth x; 
   0#0j; 
-  d#{first raze over x}each(d{each[x;]}\count)@\:x]}  / FIXME correct for shape 0#0
+  d#{first raze over x}each(d{each[x;]}\count)@\:x]}
 tc:('[til;count])
 tt:{2 vs til "j"$2 xexp x}				/ truth table of order x
 zm:{(2#count x)#0}                  	/ zero matrix (square matrix)

--- a/docs/rank.md
+++ b/docs/rank.md
@@ -12,7 +12,7 @@ The rank of an array is the depth to which it is rectangular.
 ```q
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze over x]}
+  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
 shape:{$[0=d:depth x; 
   0#0j; 
   d#{first raze over x}each(d{each[x;]}\count)@\:x]}
@@ -29,7 +29,7 @@ The number of dimensions: the depth of nesting to which the array is rectangular
 ```q
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze over x]}
+  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
 ```
 
 ```q

--- a/docs/rank.md
+++ b/docs/rank.md
@@ -12,7 +12,7 @@ The rank of an array is the depth to which it is rectangular.
 ```q
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
+  "j"$sum(and)scan 1b,-1_{1=count distinct count each x}each raze scan x]}
 shape:{$[0=d:depth x; 
   0#0j; 
   d#{first raze over x}each(d{each[x;]}\count)@\:x]}
@@ -29,7 +29,7 @@ The number of dimensions: the depth of nesting to which the array is rectangular
 ```q
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each raze scan x]}
+  "j"$sum(and)scan 1b,-1_{1=count distinct count each x}each raze scan x]}
 ```
 
 ```q
@@ -39,8 +39,8 @@ q)depth enlist 0                            / 1-item vector
 1
 q)depth "the quick brown fox"               / vector
 1
-q)depth("the";"quick";"brown";"fox")        / list - not rectangular at any depth
-0
+q)depth("the";"quick";"brown";"fox")        / list - not rectangular at 2-nd depth
+1
 q)depth("the  ";"quick";"brown";"fox  ")    / matrix
 2
 q)depth 2 3 4#til 24
@@ -57,7 +57,7 @@ The shape of an array is its count in each dimension: each level of nesting at w
 ```q
 depth:{$[type[x]<0; 
   0; 
-  "j"$sum(and)scan{1=count distinct count each x}each(raze\)x]}
+  "j"$sum(and)scan 1b,-1_{1=count distinct count each x}each(raze\)x]}
 ```
 
 ```q
@@ -82,25 +82,14 @@ The shape of an atom is an empty vector.
 ```q
 q)shape 2 3 4#til 24                        / rank-3 array
 2 3 4
+q)shape("the";"quick";"brown";"fox")        / list - not rectangular at 2-nd depth
+,4
 q)shape("the  ";"quick";"brown";"fox  ")    / matrix
 4 5
 q)shape "the quick brown fox"               / vector
 ,19
 q)shape 3                                   / atom
 `long$()
-```
-
-==FIXME shape  and depth of a non-rectangular list==
-
-```q
-q)depth("the";"quick";"brown";"fox")        / wrong
-0
-q)depth("the";"quick";"brown";"fox")        / right
-1
-q)shape("the";"quick";"brown";"fox")        / wrong
-`long$()
-q)shape("the";"quick";"brown";"fox")        / right
-,4
 ```
 
 The shape of an empty list is `1#0 `.

--- a/docs/wikipage.md
+++ b/docs/wikipage.md
@@ -768,7 +768,7 @@ The [depth](https://code.kx.com/q/basics/glossary/#depth) of a list is the numbe
 Its _shape_ is a vector of its count at each level at which it is rectangular, and corresponds to the left argument of [Take](/q/ref/take/).
 
 ```q
-q)depth:{$[type[x]<0; 0; "j"$sum(and)scan{1=count distinct count each x}each(raze\)x]}
+q)depth:{$[type[x]<0; 0; "j"$sum(and)scan 1b,-1_{1=count distinct count each x}each(raze\)x]}
 q)shape:{$[0=d:depth x; 0#0j; d#{first(raze/)x}each(d{each[x;]}\count)@\:x]}
 q)ix:('[{x vs til prd x};shape])
 q)ix til 6


### PR DESCRIPTION
One variant of depth in phrases: `depth:{$[type[x]<0; 0; "j"$sum(and)scan{1=count distinct count each x}each(raze\)x]}` works fine. So I just fixed another one.