### PR TITLE
fix: less a quote

### DIFF
--- a/docs/find.md
+++ b/docs/find.md
@@ -170,7 +170,7 @@ q)reverse[x]?y
 ### Distinct items
 
 ```q
-q)x:("banana";"pear";apple";"cherry";"apple";"orange";"pear")
+q)x:("banana";"pear";"apple";"cherry";"apple";"orange";"pear")
 q)distinct x
 "banana"
 "pear"


### PR DESCRIPTION
Hi there,

"apple" is less a quote in this code.

q)x:("banana";"pear"**;apple"**;"cherry";"apple";"orange";"pear")
